### PR TITLE
[minor] [documentation] fix the artifact id 

### DIFF
--- a/infinispan.adoc
+++ b/infinispan.adoc
@@ -9,7 +9,7 @@ To use the Infinispan fraction, just add it to your `pom.xml`.
 ----
 <dependency>
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>infinispan</artifactId>
+  <artifactId>wildfly-swarm-infinispan</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
The correct artifact ID for the infinispan fraction seems to be the following

```
<dependency>
  <groupId>org.wildfly.swarm</groupId>
  <artifactId>wildfly-swarm-infinispan</artifactId>
</dependency>
```

and not the following

```
<dependency>
  <groupId>org.wildfly.swarm</groupId>
  <artifactId>infinispan</artifactId>
</dependency>
```
