### PR TITLE
Amend pom artifactId directive

### DIFF
--- a/common/jax-rs.adoc
+++ b/common/jax-rs.adoc
@@ -38,7 +38,7 @@ By default, JAX-RS does not provide CDI support.  To bring CDI support to your a
 ----
 <dependency>
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>jaxrs-weld</artifact>
+  <artifactId>jaxrs-weld</artifactId>
 </dependency>
 ----
     


### PR DESCRIPTION
The artifactId xml closing tag in the jaxrs-weld maven dependency definition is missing the final _Id_. This change fixes the issue.
