### PR TITLE
Fix link to Management Console section

### DIFF
--- a/servers.adoc
+++ b/servers.adoc
@@ -7,4 +7,4 @@ portion of the repository.
 * <<server/microprofile#,MicroProfile>>
 * <<server/keycloak#,Keycloak>>
 * <<server/swagger_ui#,Swagger UI>>
-* <<server/management_console#,Management Console>>
+* <<server/management-console#,Management Console>>


### PR DESCRIPTION
File name is different to the one used as the link reference