### PR TITLE
Add asciidoc-admonition-icons plugin.

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,7 +9,8 @@
       "expandable-chapters",
       "edit-link",
       "addcssjs",
-      "ga"
+      "ga",
+      "asciidoc-admonition-icons"
   ],
   "pluginsConfig": {
           "edit-link": {

--- a/styles/asciidoc.css
+++ b/styles/asciidoc.css
@@ -9,21 +9,6 @@
   font-weight: bold;
 }
 
-.note .icon {
-  background-color: #1C6EAC;
-  color:white;
-}
-
-.warn .icon {
-  background-color: #AC1713;
-  color:white;
-}
-
-.tipp .icon {
-  background-color: #6CA36F;
-  color:white;
-}
-
 table thead th, table tfoot th { font-weight: bold; }
 
 table.tableblock.grid-all { border-collapse: separate; border-spacing: 1px; -webkit-border-radius: 4px; border-radius: 4px; border-top: 1px solid #dddddd; border-bottom: 1px solid #dddddd; }


### PR DESCRIPTION
Here are some screenshots:

![image](https://cloud.githubusercontent.com/assets/423513/26098883/0c46ebd2-3a21-11e7-92e2-feb6771defd5.png)

![image](https://cloud.githubusercontent.com/assets/423513/26098973/4911e256-3a21-11e7-8b64-c29b9676cc5b.png)

![image](https://cloud.githubusercontent.com/assets/423513/26099096/9e5d9264-3a21-11e7-9a80-692b8fb58d06.png)

If you want to customise the colours, icons, classes, etc, you can do it as per the docs:

https://github.com/msavy/gitbook-plugin-asciidoc-admonition-icons#basic-configuration

FWIW, I tried with GitBook 3.x.x and it looked great. I have issues getting GitBook 2.x.x running on my machine at all due to an NPM bug, seemingly. So, I do suggest you double check - it does seems fine. 
